### PR TITLE
Versioning script has been added to the the fed-main app

### DIFF
--- a/fed-main/.eslintrc.js
+++ b/fed-main/.eslintrc.js
@@ -1,17 +1,17 @@
 module.exports = {
+  root: true,
   env: {
+    browser: true,
+    es2021: true,
     node: true,
     'vue/setup-compiler-macros': true,
   },
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:vue/vue3-recommended', 'prettier'],
-  rules: {
-    // override/add rules settings here, such as:
-    // 'vue/no-unused-vars': 'error'
-  },
+  rules: {},
   parser: 'vue-eslint-parser',
   parserOptions: {
     parser: '@typescript-eslint/parser',
-    ecmaVersion: 2020,
+    ecmaVersion: 2021,
     sourceType: 'module',
   },
 }

--- a/fed-main/package.json
+++ b/fed-main/package.json
@@ -17,10 +17,12 @@
     "@heroicons/vue": "^1.0.6",
     "@tailwindcss/forms": "^0.5.0",
     "@vueuse/core": "^7.7.1",
+    "simple-git": "^3.4.0",
     "vue": "^3.2.25",
     "vue-router": "4"
   },
   "devDependencies": {
+    "@types/node": "^17.0.21",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.13.0",
     "@vitejs/plugin-vue": "^2.2.0",

--- a/fed-main/package.json
+++ b/fed-main/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src",
     "format": "prettier .  --write",
-    "version--patch": "npm version patch",
+    "version--patch": "npm version patch && tsc versioning.ts && node versioning.js",
     "version--minor": "npm version minor",
     "version--major": "npm version major"
   },
@@ -36,6 +36,7 @@
     "postcss": "^8.4.7",
     "prettier": "2.5.1",
     "tailwindcss": "^3.0.23",
+    "types-package-json": "^2.0.39",
     "typescript": "^4.5.4",
     "vite": "^2.8.0",
     "vite-plugin-eslint": "^1.3.0",

--- a/fed-main/package.json
+++ b/fed-main/package.json
@@ -10,7 +10,10 @@
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src",
-    "format": "prettier .  --write"
+    "format": "prettier .  --write",
+    "version--patch": "npm version patch",
+    "version--minor": "npm version minor",
+    "version--major": "npm version major"
   },
   "dependencies": {
     "@headlessui/vue": "^1.5.0",

--- a/fed-main/versioning.ts
+++ b/fed-main/versioning.ts
@@ -10,8 +10,8 @@ const version = packageJson.version
 
 try {
   git.add('./package.json')
-  git.commit(`Version bump to ${version}`)
-  git.addAnnotatedTag(version, `Increment version to ${version}`)
+  git.commit(`fed-main version bump to ${version}`)
+  git.addAnnotatedTag(`fed-main-${version}`, `Frontend Main app has been increased to version: ${version}`)
 } catch (error) {
   console.error(error)
 }

--- a/fed-main/versioning.ts
+++ b/fed-main/versioning.ts
@@ -11,7 +11,7 @@ const version = packageJson.version
 try {
   git.add('./package.json')
   git.commit(`Version bump to ${version}`)
-  git.addAnnotatedTag(version, `Increment version to ${version.substring(1, version.length)}`)
+  git.addAnnotatedTag(version, `Increment version to ${version}`)
 } catch (error) {
   console.error(error)
 }

--- a/fed-main/versioning.ts
+++ b/fed-main/versioning.ts
@@ -1,9 +1,17 @@
-import * as fs from 'fs'
 import simpleGit, { SimpleGit, CleanOptions } from 'simple-git'
+import type { PackageJson } from 'types-package-json'
+import * as fs from 'fs'
 
 const git: SimpleGit = simpleGit().clean(CleanOptions.FORCE)
 
 const rawData = fs.readFileSync('package.json')
-const packageJSON = JSON.parse(rawData.toString())
+const packageJson: Partial<PackageJson> = JSON.parse(rawData.toString())
+const version = packageJson.version
 
-console.log(packageJSON)
+console.log(`Current version: ${version}`)
+
+// try {
+//   git.addAnnotatedTag(version, `Increment version to ${version.substring(1, version.length)}`)
+// } catch (error) {
+//   console.error(error)
+// }

--- a/fed-main/versioning.ts
+++ b/fed-main/versioning.ts
@@ -8,10 +8,10 @@ const rawData = fs.readFileSync('package.json')
 const packageJson: Partial<PackageJson> = JSON.parse(rawData.toString())
 const version = packageJson.version
 
-console.log(`Current version: ${version}`)
-
-// try {
-//   git.addAnnotatedTag(version, `Increment version to ${version.substring(1, version.length)}`)
-// } catch (error) {
-//   console.error(error)
-// }
+try {
+  git.add('./package.json')
+  git.commit(`Version bump to ${version}`)
+  git.addAnnotatedTag(version, `Increment version to ${version.substring(1, version.length)}`)
+} catch (error) {
+  console.error(error)
+}

--- a/fed-main/versioning.ts
+++ b/fed-main/versioning.ts
@@ -1,0 +1,9 @@
+import * as fs from 'fs'
+import simpleGit, { SimpleGit, CleanOptions } from 'simple-git'
+
+const git: SimpleGit = simpleGit().clean(CleanOptions.FORCE)
+
+const rawData = fs.readFileSync('package.json')
+const packageJSON = JSON.parse(rawData.toString())
+
+console.log(packageJSON)

--- a/fed-main/yarn.lock
+++ b/fed-main/yarn.lock
@@ -2218,6 +2218,11 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
+types-package-json@^2.0.39:
+  version "2.0.39"
+  resolved "https://registry.yarnpkg.com/types-package-json/-/types-package-json-2.0.39.tgz#940466c69674a42c2453c54a8d5735a2ffb31d47"
+  integrity sha512-c8ua5W1Uu6x7LAwtwSGCl46cHmj+r2eAA+lXR1CluIZotu9V03ZHcGB9wKRZE2oIAX5IzMP/rxDV9g9ikCg9Nw==
+
 typescript@^4.5.4:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"

--- a/fed-main/yarn.lock
+++ b/fed-main/yarn.lock
@@ -125,6 +125,18 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@kwsites/file-exists@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
+  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
+  dependencies:
+    debug "^4.1.1"
+
+"@kwsites/promise-deferred@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
+  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -165,6 +177,11 @@
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
+"@types/node@^17.0.21":
+  version "17.0.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
+  integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -773,6 +790,13 @@ debug@^4.0.1, debug@^4.1.1, debug@^4.3.2:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
+
+debug@^4.3.3:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -2026,6 +2050,15 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+simple-git@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.4.0.tgz#dea49dfafbc16a67b26221917fca1caaeb976e4a"
+  integrity sha512-sBRdudUc1yvi0xQQPuHXc1L9gTWkRn4hP2bbc7q4BTxR502d3JJAGsDOhrmsBY+wAZAw5JLl82tx55fSWYE65w==
+  dependencies:
+    "@kwsites/file-exists" "^1.1.1"
+    "@kwsites/promise-deferred" "^1.1.1"
+    debug "^4.3.3"
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
A script to do major, minot and patch versions has been added to the fed-main app.

The logic of the script is in the versioning.ts app.